### PR TITLE
Use Maven Profiles and add Sonarqube analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,19 @@ cache:
   - $HOME/.m2  
 addons:
   srcclr: true  
-install:
-  - mvn --settings .travis/settings.xml install -DskipTests=true -B -V
+  sonarqube:
+    organization: "albahrani"
+    branches:
+      - master
+      - addmvnprofiles   
 before_install:
   - echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 keys.asc.gpg  
-  - gpg --batch --yes --import keys.asc
+  - gpg --batch --yes --import keys.asc      
+install:
+  - mvn --settings .travis/settings.xml install -DskipTests=true -B -V
+script:
+  # JaCoCo is used to have code coverage, the agent has to be activated
+  - mvn --settings .travis/settings.xml clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar  
 deploy:
   -
     provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 addons:
   srcclr: true  
   sonarqube:
+    organization: "albahrani-github"
     branches:
       - master
       - addmvnprofiles   

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 addons:
   srcclr: true  
 install:
-  - mvn --settings .travis/settings.xml install -DskipTests=true -Dgpg.skip -Dmaven.javadoc.skip=true -B -V
+  - mvn --settings .travis/settings.xml install -DskipTests=true -B -V
 before_install:
   - echo $GPG_PASSPHRASE | gpg --passphrase-fd 0 keys.asc.gpg  
   - gpg --batch --yes --import keys.asc

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 addons:
   srcclr: true  
   sonarqube:
-    organization: "albahrani"
     branches:
       - master
       - addmvnprofiles   

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -26,4 +26,4 @@ else
     echo "not on a tag -> keep snapshot version in pom.xml"
 fi
 
-mvn clean deploy --settings .travis/settings.xml -DskipTests=true -B -U
+mvn clean deploy --settings .travis/settings.xml -DskipTests=true -P attachJdocSources,deployToOssrh -B -U

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/albahrani/dimmingplan.svg?branch=master)](https://travis-ci.org/albahrani/dimmingplan)
+[![Quality Gate](https://sonarqube.com/api/badges/gate?key=com.github.albahrani:dimmingplan)](https://sonarqube.com/dashboard/index/com.github.albahrani:dimmingplan)
 # dimmingplan | dimming timetable for Java
 Realize timetable based dimming with interpolation in Java.
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,17 +46,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
-
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -114,59 +103,91 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-			<!-- Plugin for deployment to OSS Sonatype -->
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.3</version>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.5</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+			</plugin>			
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>attachJdocSources</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>	
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>2.4</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.10.3</version>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>					
+				</plugins>
+			</build>
+		</profile>					
+		<profile>
+			<id>deployToOssrh</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<distributionManagement>
+				<snapshotRepository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+				</snapshotRepository>
+				<repository>
+					<id>ossrh</id>
+					<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+				</repository>
+			</distributionManagement>			
+			<build>
+				<plugins>
+				<!-- Plugin for deployment to OSS Sonatype -->
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<version>1.6.7</version>
+						<extensions>true</extensions>
+						<configuration>
+							<serverId>ossrh</serverId>
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.5</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>			
+				</plugins>
+			</build>
+		</profile>
+	</profiles>		
 </project>


### PR DESCRIPTION
Using Profile `attachJdocSources `for attaching source code and Javadoc.
Using Profile `deployToOssrh` for gpg signing and deployment to Maven Central.
Added Sonarqube analysis to travis build.